### PR TITLE
Instantiate with new token setup option

### DIFF
--- a/contracts/tokenfactory-issuer/Cargo.toml
+++ b/contracts/tokenfactory-issuer/Cargo.toml
@@ -36,6 +36,7 @@ cw-storage-plus = "0.13.2"
 cw2 = "0.13.2"
 osmo-bindings = {git = "https://github.com/osmosis-labs/bindings", branch = "main"}
 osmosis-std = {git = "https://github.com/osmosis-labs/osmosis-rust", branch = "boss/tokenfactory-ext"}
+prost = "0.11.0"
 schemars = "0.8.8"
 serde = {version = "1.0.137", default-features = false, features = ["derive"]}
 thiserror = {version = "1.0.31"}

--- a/contracts/tokenfactory-issuer/src/contract.rs
+++ b/contracts/tokenfactory-issuer/src/contract.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, SubMsg,
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, SubMsg,
 };
 use cosmwasm_std::{CosmosMsg, Reply};
 use cw2::set_contract_version;
@@ -80,7 +80,7 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response<OsmosisMsg>, ContractError> {
-    //
+    // after instantiate contract
     if msg.id == CREATE_DENOM_REPLY_ID {
         let MsgCreateDenomResponse { new_token_denom } = msg.result.try_into()?;
 

--- a/contracts/tokenfactory-issuer/src/contract.rs
+++ b/contracts/tokenfactory-issuer/src/contract.rs
@@ -1,9 +1,15 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cosmwasm_std::{
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, SubMsg,
+};
+use cosmwasm_std::{CosmosMsg, Reply};
 use cw2::set_contract_version;
 
 use osmo_bindings::OsmosisMsg;
+use osmosis_std::types::osmosis::tokenfactory::v1beta1::{
+    MsgCreateDenom, MsgCreateDenomResponse, MsgSetBeforeSendListener,
+};
 
 use crate::error::ContractError;
 use crate::execute;
@@ -16,27 +22,98 @@ use crate::state::{Config, CONFIG};
 const CONTRACT_NAME: &str = "crates.io:tokenfactory-issuer";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+const CREATE_DENOM_REPLY_ID: u64 = 1;
+
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response<OsmosisMsg>, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    let config = Config {
-        owner: info.sender.clone(),
-        is_frozen: false,
-        denom: msg.denom.clone(),
-    };
+    match msg {
+        InstantiateMsg::NewToken { subdenom } => {
+            let msg_create_denom: CosmosMsg<OsmosisMsg> = MsgCreateDenom {
+                sender: env.contract.address.to_string(),
+                subdenom: subdenom.clone(),
+            }
+            .into();
 
-    CONFIG.save(deps.storage, &config)?;
+            let config = Config {
+                owner: info.sender.clone(),
+                is_frozen: false,
+                // to be updated after create denom
+                denom: "".to_string(),
+            };
 
-    Ok(Response::new()
-        .add_attribute("action", "instantiate")
-        .add_attribute("owner", info.sender)
-        .add_attribute("denom", msg.denom))
+            CONFIG.save(deps.storage, &config)?;
+
+            Ok(Response::new()
+                .add_attribute("action", "instantiate")
+                .add_attribute("owner", info.sender)
+                .add_attribute("subdenom", subdenom)
+                .add_submessage(SubMsg::reply_on_success(
+                    msg_create_denom,
+                    CREATE_DENOM_REPLY_ID,
+                )))
+        }
+        InstantiateMsg::ExistingToken { denom } => {
+            let config = Config {
+                owner: info.sender.clone(),
+                is_frozen: false,
+                denom: denom.clone(),
+            };
+
+            CONFIG.save(deps.storage, &config)?;
+
+            Ok(Response::new()
+                .add_attribute("action", "instantiate")
+                .add_attribute("owner", info.sender)
+                .add_attribute("denom", denom))
+        }
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response<OsmosisMsg>, ContractError> {
+    if msg.id == CREATE_DENOM_REPLY_ID {
+        // parse response from create denom
+        let response = msg
+            .result
+            .into_result()
+            .map_err(|e| StdError::GenericErr { msg: e })?
+            .data
+            .ok_or_else(|| StdError::NotFound {
+                kind: stringify!(MsgCreateDenomResponse).to_string(),
+            })?;
+
+        let MsgCreateDenomResponse { new_token_denom } =
+            prost::Message::decode(response.to_vec().as_slice()).map_err(|e| {
+                StdError::parse_err(stringify!(MsgCreateDenomResponse), e.to_string())
+            })?;
+
+        CONFIG.update(deps.storage, |config| {
+            Result::<Config, ContractError>::Ok(Config {
+                denom: new_token_denom.clone(),
+                ..config
+            })
+        })?;
+
+        let msg_set_beforesend_listener: CosmosMsg<OsmosisMsg> = MsgSetBeforeSendListener {
+            sender: env.contract.address.to_string(),
+            denom: new_token_denom.clone(),
+            cosmwasm_address: env.contract.address.to_string(),
+        }
+        .into();
+
+        return Ok(Response::new()
+            .add_attribute("denom", new_token_denom)
+            .add_message(msg_set_beforesend_listener));
+    }
+
+    unreachable!()
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/tokenfactory-issuer/src/contract_tests.rs
+++ b/contracts/tokenfactory-issuer/src/contract_tests.rs
@@ -15,7 +15,7 @@ static CREATOR_ADDRESS: &str = "creator";
 #[allow(unused_assignments)]
 fn initialize_contract(deps: DepsMut) -> (Addr, String) {
     let denom = String::from("factory/creator/uusd");
-    let msg = InstantiateMsg {
+    let msg = InstantiateMsg::ExistingToken {
         denom: denom.clone(),
     };
     let info = mock_info(CREATOR_ADDRESS, &[]);

--- a/contracts/tokenfactory-issuer/src/msg.rs
+++ b/contracts/tokenfactory-issuer/src/msg.rs
@@ -2,8 +2,14 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Coin, Uint128};
 
 #[cw_serde]
-pub struct InstantiateMsg {
-    pub denom: String,
+pub enum InstantiateMsg {
+    /// `NewToken` will create a new token when instantiate the contract.
+    /// Newly created token will have full denom as `factory/<contract_address>/<subdenom>`.
+    /// It will be attached to the contract setup the beforesend listener automatically.
+    NewToken { subdenom: String },
+    /// `ExistingToken` will use already created token. So to set this up,
+    /// token admin needs to create a new token and set beforesend listener manually.
+    ExistingToken { denom: String },
 }
 
 #[cw_serde]


### PR DESCRIPTION
Add option to contract instantiation process to be able to "create new denom" and "set beforesend listener".

More testing will be added when https://github.com/osmosis-labs/osmosis/pull/2895 is merged and update `osmosis-testing` along with it. That will enable proper testing with reply.

## Changes
- Add option to instantiate with token setup
- use osmosis-std type's conversion to extract submsg result
- add comments to explain the process
